### PR TITLE
Feat: Add tab query params to dashboard page

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -16,6 +16,12 @@ import { SettingsComponent } from './features/settings/settings.component';
 export const ROUTES: Routes = [
   {
     path: '',
+    component: LandingPageComponent,
+    canActivate: [AuthenticationGuard],
+    data: { blockAuthenticated: true, redirectToSignIn: false },
+  },
+  {
+    path: 'dashboard',
     component: DashboardComponent,
     canActivate: [AuthenticationGuard],
     data: { blockAuthenticated: false, redirectToSignIn: false },
@@ -61,12 +67,6 @@ export const ROUTES: Routes = [
     component: SettingsComponent,
     canActivate: [AuthenticationGuard],
     data: { blockAuthenticated: false, redirectToSignIn: true },
-  },
-  {
-    path: 'welcome',
-    component: LandingPageComponent,
-    canActivate: [AuthenticationGuard],
-    data: { blockAuthenticated: true, redirectToSignIn: false },
   },
   {
     path: 'sign-up',

--- a/src/app/core/components/header-button/header-button.component.html
+++ b/src/app/core/components/header-button/header-button.component.html
@@ -18,9 +18,8 @@
     <ng-template [ngIf]="account">
       <a
         class="sidebar-button"
-        [routerLink]="['/']"
+        [routerLink]="['/dashboard']"
         [routerLinkActive]="['active']"
-        [routerLinkActiveOptions]="{ exact: true }"
         (click)="sidebarVisible = false">
         Dashboard
       </a>

--- a/src/app/core/components/main-navigation/main-navigation.component.html
+++ b/src/app/core/components/main-navigation/main-navigation.component.html
@@ -3,9 +3,8 @@
   <span class="nav-divider"></span>
   <a
     class="nav-button"
-    [routerLink]="['/']"
-    [routerLinkActive]="['active']"
-    [routerLinkActiveOptions]="{ exact: true }">
+    [routerLink]="['/dashboard']"
+    [routerLinkActive]="['active']">
     Dashboard
   </a>
   <a

--- a/src/app/core/models/album.interface.ts
+++ b/src/app/core/models/album.interface.ts
@@ -22,12 +22,3 @@ export interface UserAlbum {
   added_on: number;
   score?: number;
 }
-
-export interface AlbumRow {
-  id: string;
-  title: string;
-  artist: string;
-  progress: string;
-  format: string;
-  added_on: number;
-}

--- a/src/app/core/models/game.interface.ts
+++ b/src/app/core/models/game.interface.ts
@@ -22,12 +22,3 @@ export interface UserGame {
   added_on: number;
   score?: number;
 }
-
-export interface GameRow {
-  id: string;
-  title: string;
-  platform: string;
-  progress: string;
-  format: string;
-  added_on: number;
-}

--- a/src/app/core/models/movie.interface.ts
+++ b/src/app/core/models/movie.interface.ts
@@ -21,12 +21,3 @@ export interface UserMovie {
   added_on: number;
   score?: number;
 }
-
-export interface MovieRow {
-  id: string;
-  title: string;
-  director: string;
-  progress: string;
-  format: string;
-  added_on: number;
-}

--- a/src/app/core/services/authentication.guard.ts
+++ b/src/app/core/services/authentication.guard.ts
@@ -19,12 +19,12 @@ export class AuthenticationGuard implements CanActivate {
     return this.authenticationService.getUser().pipe(
       map((user) => {
         if (route.data['blockAuthenticated']) {
-          return user ? this.router.parseUrl('/') : true;
+          return user ? this.router.parseUrl('/dashboard') : true;
         }
         return user
           ? true
           : this.router.parseUrl(
-              route.data['redirectToSignIn'] ? '/sign-in' : '/welcome',
+              route.data['redirectToSignIn'] ? '/sign-in' : '/',
             );
       }),
     );

--- a/src/app/core/services/users.service.ts
+++ b/src/app/core/services/users.service.ts
@@ -5,10 +5,10 @@ import {
 } from '@angular/fire/compat/firestore';
 import { User, UserCollection } from '../models/user.interface';
 import { firstValueFrom, map, of, switchMap, take } from 'rxjs';
-import { GameRow, UserGame } from '../models/game.interface';
+import { UserGame } from '../models/game.interface';
 import { AuthenticationService } from './authentication.service';
-import { MovieRow, UserMovie } from '../models/movie.interface';
-import { AlbumRow, UserAlbum } from '../models/album.interface';
+import { UserMovie } from '../models/movie.interface';
+import { UserAlbum } from '../models/album.interface';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { statisticsTemplate } from '../../shared/templates/statistics.template';
 import {
@@ -19,7 +19,6 @@ import { RatingsService } from './ratings.service';
 import { MediaRow } from '../models/table.interface';
 
 const USERS_PATH = '/users';
-
 
 @Injectable({
   providedIn: 'root',

--- a/src/app/core/states/auth/auth.effects.ts
+++ b/src/app/core/states/auth/auth.effects.ts
@@ -81,7 +81,7 @@ export class AuthEffects {
         mergeMap(() => {
           return this.authenticationService.signOut().pipe(
             tap(() => {
-              this.router.navigate(['/welcome']);
+              this.router.navigate(['/']);
             }),
           );
         }),

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -5,7 +5,7 @@ import { UsersService } from '../../core/services/users.service';
 import { GameCardComponent } from '../../core/components/game-card/game-card.component';
 import { UserCollection } from '../../core/models/user.interface';
 import { LoadingComponent } from '../../core/layout/loading/loading.component';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, Params, Router, RouterLink } from '@angular/router';
 import { MovieCardComponent } from '../../core/components/movie-card/movie-card.component';
 import { AlbumCardComponent } from '../../core/components/album-card/album-card.component';
 import { MenuItem } from 'primeng/api';
@@ -15,6 +15,8 @@ import { UserStatistics } from '../../core/models/statistics.interface';
 import { AlbumStatisticsComponent } from '../../core/components/album-statistics/album-statistics.component';
 import { MovieStatisticsComponent } from '../../core/components/movie-statistics/movie-statistics.component';
 import { MediaTableComponent } from '../../core/components/media-table/media-table.component';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { tap } from 'rxjs';
 
 @Component({
   selector: 'app-dashboard',
@@ -47,16 +49,38 @@ export class DashboardComponent {
   ];
   activeTab: MenuItem = this.tabItems[0];
 
-  constructor(private usersService: UsersService) {
+  constructor(
+    private usersService: UsersService,
+    private route: ActivatedRoute,
+    private router: Router,
+  ) {
     usersService.getCollection().then((collection) => {
       if (collection) {
         this.collection = collection;
         this.statistics = usersService.getCollectionStatistics(collection);
       }
     });
+
+    route.queryParams.pipe(takeUntilDestroyed()).subscribe((params) => {
+      if (!params) return;
+      const mediaType = params['tab'];
+      switch (mediaType) {
+        case 'movies':
+          this.activeTab = this.tabItems[1];
+          return;
+        case 'albums':
+          this.activeTab = this.tabItems[2];
+          return;
+        default:
+          this.activeTab = this.tabItems[0];
+          return;
+      }
+    });
   }
 
   changeActiveItem(event: MenuItem) {
-    this.activeTab = event;
+    this.router.navigate(['/dashboard'], {
+      queryParams: { tab: event.label?.toLowerCase() },
+    });
   }
 }


### PR DESCRIPTION
Hey there,

this PR adds query params to the dashboard page so users can access the different tabs through the URL. Also reloading the page no longer resets the selected tab back to Games. Additionally I have moved the dashboard page from `/` to `/dashboard`. The landing-page is now at root instead (formerly at `/welcome`).

**The following components were changed**:
- Dashboard page - Added query params, changing between tabs is now also handled through query params
- App routes - Changed paths of dashboard and landing page
- Authentication guard, Auth effects and header components - Adjusted router links and urls

![20231006_170000](https://github.com/m-m-mic/Me-My-Shelf-and-I/assets/85286401/cca5cf77-70d8-4ed9-8b25-a9740bb8da03)

The GIF above shows how the params change when changing tabs and that the tab persists after a reload.

___

Thanks for the review!