### PR TITLE
Fix: make select buttons required

### DIFF
--- a/src/app/features/album/album.component.html
+++ b/src/app/features/album/album.component.html
@@ -32,7 +32,7 @@
   <div class="form-header">
     <h2>Your Details</h2>
     <p-button
-      [disabled]="!userAlbumData?.in_collection"
+      [disabled]="!userAlbumData?.in_collection || albumForm.valid"
       label="Save"
       icon="pi pi-check"
       size="small"

--- a/src/app/features/album/album.form.ts
+++ b/src/app/features/album/album.form.ts
@@ -1,5 +1,5 @@
 import { DocumentReference } from '@angular/fire/compat/firestore';
-import { FormGroup } from '@angular/forms';
+import { FormGroup, Validators } from '@angular/forms';
 import { Album, UserAlbum } from '../../core/models/album.interface';
 
 export function fillAlbumForm(userAlbumData?: UserAlbum) {
@@ -7,12 +7,14 @@ export function fillAlbumForm(userAlbumData?: UserAlbum) {
     return {
       format: [
         { value: userAlbumData.format, disabled: !userAlbumData.in_collection },
+        Validators.required,
       ],
       progress: [
         {
           value: userAlbumData.progress,
           disabled: !userAlbumData.in_collection,
         },
+        Validators.required,
       ],
       notes: [
         { value: userAlbumData.notes, disabled: !userAlbumData.in_collection },

--- a/src/app/features/game/game.form.ts
+++ b/src/app/features/game/game.form.ts
@@ -7,9 +7,11 @@ export function fillGameForm(userGameData?: UserGame) {
     return {
       format: [
         { value: userGameData.format, disabled: !userGameData.in_collection },
+        Validators.required,
       ],
       progress: [
         { value: userGameData.progress, disabled: !userGameData.in_collection },
+        Validators.required,
       ],
       notes: [
         { value: userGameData.notes, disabled: !userGameData.in_collection },

--- a/src/app/features/movie/movie.component.html
+++ b/src/app/features/movie/movie.component.html
@@ -32,7 +32,7 @@
   <div class="form-header">
     <h2>Your Details</h2>
     <p-button
-      [disabled]="!userMovieData?.in_collection"
+      [disabled]="!userMovieData?.in_collection || !movieForm.valid"
       label="Save"
       icon="pi pi-check"
       size="small"

--- a/src/app/features/movie/movie.form.ts
+++ b/src/app/features/movie/movie.form.ts
@@ -1,4 +1,4 @@
-import { FormGroup } from '@angular/forms';
+import { FormGroup, Validators } from '@angular/forms';
 import { DocumentReference } from '@angular/fire/compat/firestore';
 import { Movie, UserMovie } from '../../core/models/movie.interface';
 
@@ -7,12 +7,14 @@ export function fillMovieForm(userMovieData?: UserMovie) {
     return {
       format: [
         { value: userMovieData.format, disabled: !userMovieData.in_collection },
+        Validators.required,
       ],
       progress: [
         {
           value: userMovieData.progress,
           disabled: !userMovieData.in_collection,
         },
+        Validators.required,
       ],
       notes: [
         { value: userMovieData.notes, disabled: !userMovieData.in_collection },


### PR DESCRIPTION
Hey there,

this PR makes the select buttons on the media item pages required to prevent undefined entries.